### PR TITLE
chore(renovate): group Vercel AI SDK deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
   "prHourlyLimit": 0,
   "packageRules": [
     {
+      "matchPackageNames": ["ai", "@ai-sdk/react", "@ai-sdk/openai"],
+      "groupName": "Vercel AI SDK",
+      "groupSlug": "vercel-ai-sdk"
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },


### PR DESCRIPTION
Groups `ai`, `@ai-sdk/react`, and `@ai-sdk/openai` into a single Renovate PR via `packageRules`.\n\nValidated with: `npx --yes --package renovate -- renovate-config-validator --strict`.